### PR TITLE
feat: add generic dependabot-cleanup skill

### DIFF
--- a/mac/claude/setup.sh
+++ b/mac/claude/setup.sh
@@ -5,3 +5,6 @@ mkdir -p ~/.claude
 ln -sf ~/dotfiles/mac/claude/CLAUDE.md ~/.claude/CLAUDE.md
 ln -sf ~/dotfiles/mac/claude/settings.json ~/.claude/settings.json
 ln -sf ~/dotfiles/mac/claude/statusline.sh ~/.claude/statusline.sh
+
+# claude skills
+ln -sfn ~/dotfiles/mac/claude/skills ~/.claude/skills

--- a/mac/claude/skills/dependabot-cleanup/SKILL.md
+++ b/mac/claude/skills/dependabot-cleanup/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: dependabot-cleanup
+description: Dependabotアラートを一括で分析・対応する。直接依存はアップデートし、推移的依存はdismissする。Node.js（pnpm）とGoに対応。
+allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*), Bash(pnpm *), Bash(go *), Read, Glob, Grep
+---
+
+# Dependabot アラートお掃除スキル
+
+## 重要: GitHub API直接呼び出しの禁止
+
+以下のコマンドは絶対に使用しないこと：
+
+```bash
+# 禁止: gh api を直接使用
+gh api /repos/{owner}/{repo}/dependabot/alerts
+gh api --method PATCH /repos/{owner}/{repo}/dependabot/alerts/{number}
+
+# 代わりに: 必ず scripts/ 配下のスクリプトを使用する
+${CLAUDE_SKILL_DIR}/scripts/get-open-alerts.sh
+${CLAUDE_SKILL_DIR}/scripts/dismiss-alert.sh 123 tolerable_risk "reason"
+```
+
+## 実行フロー
+
+### Phase 1: アラート一覧取得
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/get-open-alerts.sh
+```
+
+owner/repo は git remote origin から自動検出される。
+出力されるJSON配列から全オープンアラートを把握する。
+
+### Phase 2: 分類
+
+各アラートを以下の手順で分類する：
+
+1. **エコシステム判定**（manifest_path / ecosystem フィールドから）
+   - `package.json` / `pnpm-lock.yaml` / `package-lock.json` / `yarn.lock` → **Node.js**
+   - `go.sum` / `go.mod` → **Go**
+
+2. **直接依存か推移的依存かの判定**
+   - **Node.js**: 該当 `package.json` を Read ツールで読み、`dependencies` / `devDependencies` にパッケージ名が存在するか確認
+   - **Go**: `go.mod` を Read ツールで読み、`require` ブロック内で `// indirect` コメントがないものが直接依存
+
+3. **分類カテゴリ**
+   - **A. 直接アップデート可能**: 依存定義ファイルに直接記載
+   - **B. 推移的依存（上流待ち）**: 上流パッケージのアップデートが必要
+   - **C. 環境非該当/リスク低**: OS限定脆弱性やdevDependency限定で影響軽微
+
+分類結果をテーブル形式でユーザーに提示し、方針を確認する。
+
+### Phase 3: アップデート（カテゴリA）
+
+#### Node.js (pnpm)
+
+| package.jsonの記法 | 手段 |
+|---|---|
+| `"^1.0.0"` / `"~1.0.0"` （レンジ指定） | `pnpm update <pkg>` |
+| `"1.2.3"` （固定バージョン） | `pnpm add [-D] <pkg>@<target-version>` |
+
+**注意事項**:
+- `@latest` は絶対に使わない。メジャーバージョンが上がりピアデペンデンシーが崩壊する
+- `first_patched_version` を参照し最小限のバージョンアップに留める（`${CLAUDE_SKILL_DIR}/scripts/get-alert-detail.sh` で取得可能）
+- 同一エコシステムのパッケージ群（例: storybook + @storybook/addon-*）はバージョンを揃える
+
+#### Go
+
+```bash
+go get <module>@v<patched-version>
+go mod tidy
+```
+
+**注意事項**:
+- `@latest` は使わない。`first_patched_version` で指定する
+- `go mod tidy` で不要な依存を整理する
+- 推移的依存は `go get` で直接更新できない場合がある。上流モジュールの更新を待つ
+
+### Phase 4: Dismiss（カテゴリB, C）
+
+dismissするアラートの一覧をテーブル形式でユーザーに提示し、**承認を得てから**実行する。
+
+```bash
+# 単一dismiss
+${CLAUDE_SKILL_DIR}/scripts/dismiss-alert.sh 123 tolerable_risk "Transitive dependency via textlint. Awaiting upstream update."
+
+# 一括dismiss（同一理由で複数アラート）
+${CLAUDE_SKILL_DIR}/scripts/dismiss-alerts-batch.sh "89 90 96 97" tolerable_risk "Transitive dependency. Awaiting upstream update."
+```
+
+### Phase 5: 結果レポート
+
+対応結果をテーブル形式でサマリー表示：
+
+| カテゴリ | 件数 | アラート番号 |
+|---|---|---|
+| 直接アップデートで解決 | N件 | #xxx, #yyy |
+| dismiss済み（推移的依存） | N件 | #xxx, #yyy |
+| dismiss済み（環境非該当） | N件 | #xxx, #yyy |
+| 残存（push後に自動クローズ予定） | N件 | #xxx, #yyy |
+
+## リファレンス
+
+API仕様の詳細や実戦で判明した落とし穴については `${CLAUDE_SKILL_DIR}/references/api-notes.md` を参照すること。

--- a/mac/claude/skills/dependabot-cleanup/references/api-notes.md
+++ b/mac/claude/skills/dependabot-cleanup/references/api-notes.md
@@ -1,0 +1,34 @@
+# Dependabot Alerts API 実戦メモ
+
+## dismissed_reason の有効値
+
+| 値 | 説明 |
+|---|---|
+| `fix_started` | 修正作業を開始済み |
+| `inaccurate` | アラートが不正確 |
+| `no_bandwidth` | 対応リソースなし |
+| `not_used` | 該当コードパスを使用していない |
+| `tolerable_risk` | 許容可能なリスク |
+
+**`not_impacted` は無効値。HTTP 422エラーを返す。**
+
+## dismiss理由テンプレート
+
+- 推移的依存: `Transitive dependency via {parent_package}. Awaiting upstream update.`
+- Windows限定: `Dev dependency only. Vulnerability is Windows-specific, not applicable to our macOS/Linux CI.`
+- devDependency低リスク: `Dev dependency only. Low risk in development context.`
+
+## 実戦で判明した落とし穴
+
+### Node.js (pnpm)
+
+1. **`pnpm update` が効かないケース**: package.jsonで固定バージョン指定（`"9.1.17"`等、`^`なし）の場合、`pnpm update`は「Already up to date」を返す。`pnpm add`で明示的にバージョン指定が必要
+2. **`@latest` のメジャーバージョン爆死**: `pnpm add pkg@latest`はメジャーバージョンを引く。ピアデペンデンシーが崩壊する。パッチバージョンを明示指定すること
+3. **推移的依存は`pnpm update`で更新不可**: `pnpm update <transitive-dep>`は効果なし。`pnpm.overrides`は互換性リスクがあるため原則使わない
+4. **dismiss後もアラートが残る場合**: lockfileの更新をpushすると、直接依存の更新分は自動クローズされる。push前のdismissとpush後の自動クローズは別の仕組み
+
+### Go
+
+1. **推移的依存の `go get`**: `go get <indirect-module>@version` は go.mod に直接追加されてしまう。推移的依存の更新は上流モジュールの更新（`go get <direct-module>@version`）で対応するのが正道
+2. **`go mod tidy` の副作用**: 未使用の直接依存も削除されるため、意図しない変更が入る可能性あり。差分を確認すること
+3. **`// indirect` の判定**: `go.mod` の `require` ブロック内で行末に `// indirect` コメントがあるものが推移的依存。ないものが直接依存

--- a/mac/claude/skills/dependabot-cleanup/scripts/detect-repo.sh
+++ b/mac/claude/skills/dependabot-cleanup/scripts/detect-repo.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Detect owner/repo from git remote origin.
+# Usage: source this script to set OWNER and REPO variables.
+#
+# Supports:
+#   - HTTPS: https://github.com/owner/repo.git
+#   - SSH:   git@github.com:owner/repo.git
+
+remote_url=$(git remote get-url origin 2>/dev/null) || {
+    echo "Error: Not a git repository or no 'origin' remote found" >&2
+    exit 1
+}
+
+# Strip trailing .git
+remote_url="${remote_url%.git}"
+
+if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/]+)$ ]]; then
+    OWNER="${BASH_REMATCH[1]}"
+    REPO="${BASH_REMATCH[2]}"
+else
+    echo "Error: Could not parse owner/repo from remote URL: $remote_url" >&2
+    exit 1
+fi
+
+export OWNER REPO

--- a/mac/claude/skills/dependabot-cleanup/scripts/dismiss-alert.sh
+++ b/mac/claude/skills/dependabot-cleanup/scripts/dismiss-alert.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/dismiss-alert.sh <alert_number> <reason> <comment>
+#
+# Valid reasons: fix_started, inaccurate, no_bandwidth, not_used, tolerable_risk
+# NOTE: "not_impacted" is NOT a valid value (returns HTTP 422)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/detect-repo.sh"
+
+alert_number="${1:?Usage: $0 <alert_number> <reason> <comment>}"
+reason="${2:?Usage: $0 <alert_number> <reason> <comment>}"
+comment="${3:?Usage: $0 <alert_number> <reason> <comment>}"
+
+command -v gh >/dev/null 2>&1 || { echo "Error: gh is not installed" >&2; exit 1; }
+
+[[ "$alert_number" =~ ^[0-9]+$ ]] || {
+    echo "Error: alert_number must be an integer, got: $alert_number" >&2
+    exit 1
+}
+
+valid_reasons=("fix_started" "inaccurate" "no_bandwidth" "not_used" "tolerable_risk")
+valid=false
+for r in "${valid_reasons[@]}"; do
+    [[ "$reason" == "$r" ]] && valid=true && break
+done
+$valid || {
+    echo "Error: Invalid dismissed_reason: $reason" >&2
+    echo "Valid values: ${valid_reasons[*]}" >&2
+    exit 1
+}
+
+response=$(gh api --method PATCH "repos/${OWNER}/${REPO}/dependabot/alerts/${alert_number}" \
+  -f state=dismissed \
+  -f dismissed_reason="$reason" \
+  -f dismissed_comment="$comment" 2>&1) || {
+    echo "Error: Failed to dismiss alert #${alert_number}" >&2
+    echo "$response" >&2
+    exit 1
+}
+
+echo "Dismissed #${alert_number} (${OWNER}/${REPO})"

--- a/mac/claude/skills/dependabot-cleanup/scripts/dismiss-alerts-batch.sh
+++ b/mac/claude/skills/dependabot-cleanup/scripts/dismiss-alerts-batch.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/dismiss-alerts-batch.sh <alert_numbers> <reason> <comment>
+# alert_numbers: space-separated list of alert numbers (e.g., "89 90 96 97")
+#
+# Valid reasons: fix_started, inaccurate, no_bandwidth, not_used, tolerable_risk
+# NOTE: "not_impacted" is NOT a valid value (returns HTTP 422)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+alert_numbers="${1:?Usage: $0 <alert_numbers> <reason> <comment>}"
+reason="${2:?Usage: $0 <alert_numbers> <reason> <comment>}"
+comment="${3:?Usage: $0 <alert_numbers> <reason> <comment>}"
+
+succeeded=0
+failed=0
+failed_alerts=""
+
+for alert_num in $alert_numbers; do
+    if "$SCRIPT_DIR/dismiss-alert.sh" "$alert_num" "$reason" "$comment"; then
+        ((succeeded++))
+    else
+        ((failed++))
+        failed_alerts="${failed_alerts} #${alert_num}"
+    fi
+done
+
+echo ""
+echo "=== Batch dismiss summary ==="
+echo "Succeeded: $succeeded"
+echo "Failed: $failed"
+if [[ $failed -gt 0 ]]; then
+    echo "Failed alerts:${failed_alerts}"
+    exit 1
+fi

--- a/mac/claude/skills/dependabot-cleanup/scripts/get-alert-detail.sh
+++ b/mac/claude/skills/dependabot-cleanup/scripts/get-alert-detail.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/get-alert-detail.sh <alert_number>
+# Output: JSON object with alert detail including first_patched_version
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/detect-repo.sh"
+
+alert_number="${1:?Usage: $0 <alert_number>}"
+
+command -v gh >/dev/null 2>&1 || { echo "Error: gh is not installed" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "Error: jq is not installed" >&2; exit 1; }
+
+[[ "$alert_number" =~ ^[0-9]+$ ]] || {
+    echo "Error: alert_number must be an integer, got: $alert_number" >&2
+    exit 1
+}
+
+response=$(gh api "repos/${OWNER}/${REPO}/dependabot/alerts/${alert_number}" 2>&1) || {
+    echo "Error: Failed to fetch alert #${alert_number}" >&2
+    echo "$response" >&2
+    exit 1
+}
+
+echo "$response" | jq '{
+  number,
+  package: .security_vulnerability.package.name,
+  ecosystem: .security_vulnerability.package.ecosystem,
+  vulnerable_range: .security_vulnerability.vulnerable_version_range,
+  first_patched_version: .security_vulnerability.first_patched_version.identifier,
+  manifest: .dependency.manifest_path,
+  scope: .dependency.scope,
+  severity: .security_advisory.severity,
+  summary: .security_advisory.summary,
+  advisory_url: .security_advisory.references[0].url
+}'

--- a/mac/claude/skills/dependabot-cleanup/scripts/get-open-alerts.sh
+++ b/mac/claude/skills/dependabot-cleanup/scripts/get-open-alerts.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/get-open-alerts.sh
+# Output: JSON array of open Dependabot alerts with structured fields
+# owner/repo is auto-detected from git remote origin
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/detect-repo.sh"
+
+command -v gh >/dev/null 2>&1 || { echo "Error: gh is not installed" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "Error: jq is not installed" >&2; exit 1; }
+
+echo "Fetching Dependabot alerts for ${OWNER}/${REPO}..." >&2
+
+response=$(gh api "repos/${OWNER}/${REPO}/dependabot/alerts" \
+  --paginate \
+  -q '[.[] | select(.state == "open")]' 2>&1) || {
+    echo "Error: Failed to fetch Dependabot alerts" >&2
+    echo "$response" >&2
+    exit 1
+}
+
+echo "$response" | jq '[.[] | {
+  number,
+  package: .security_vulnerability.package.name,
+  ecosystem: .security_vulnerability.package.ecosystem,
+  vulnerable_range: .security_vulnerability.vulnerable_version_range,
+  first_patched_version: .security_vulnerability.first_patched_version.identifier,
+  manifest: .dependency.manifest_path,
+  scope: .dependency.scope,
+  severity: .security_advisory.severity,
+  summary: .security_advisory.summary
+}]'

--- a/plans/2026-03-08-dependabot-cleanup-generalize.md
+++ b/plans/2026-03-08-dependabot-cleanup-generalize.md
@@ -1,0 +1,111 @@
+# Dependabot Cleanup スキル汎用化プラン
+
+## Context
+
+`homepage-2nd/.claude/commands/dependabot-cleanup/` にある Dependabot アラート対応スキルを、リポジトリ非依存の汎用スキルとして `~/.claude/commands/dependabot-cleanup/` に配置する。
+
+現状の homepage-2nd 特化要素:
+- `korosuke613 homepage-2nd` のハードコード
+- pnpm 限定のコマンド群
+- `tools/` ディレクトリ（monorepo ワークスペース）対応
+- 検証フェーズ（build-types, lint, test:unit）
+
+## 方針
+
+### 対応エコシステム
+- **Node.js**: pnpm 前提（npm/yarn 非対応）
+- **Go**: go.mod ベースの依存管理
+
+### 変更サマリー
+
+| 項目 | 現状 | 汎用版 |
+|---|---|---|
+| owner/repo | ハードコード | `git remote` から自動検出（スクリプト側） |
+| エコシステム | pnpm のみ | pnpm + Go（manifest_path で自動判定） |
+| tools/ 対応 | あり | 削除 |
+| 検証フェーズ | build-types/lint/test:unit | 削除 |
+| 配置先 | プロジェクト `.claude/commands/` | `~/.claude/commands/` |
+
+## 実装詳細
+
+### 1. `~/.claude/commands/dependabot-cleanup/SKILL.md`
+
+#### allowed-tools
+```
+Bash(./scripts/*), Bash(pnpm *), Bash(go get *), Bash(go mod *), Read, Glob, Grep
+```
+
+#### Phase 1: アラート一覧取得
+- `./scripts/get-open-alerts.sh`（引数なし、git remote から自動検出）
+
+#### Phase 2: 分類
+- **manifest_path によるエコシステム判定**:
+  - `package.json` / `pnpm-lock.yaml` / `package-lock.json` / `yarn.lock` → Node.js（pnpm）
+  - `go.sum` / `go.mod` → Go
+- **直接依存の判定**:
+  - Node.js: `package.json` の `dependencies` / `devDependencies` を確認
+  - Go: `go.mod` の `require` ブロックに `// indirect` がないものが直接依存
+- 分類カテゴリは現状通り（A: 直接, B: 推移的上流待ち, C: 環境非該当/低リスク）
+
+#### Phase 3: アップデート（カテゴリ A）
+
+**Node.js (pnpm)**:
+- レンジ指定（`^`, `~`）→ `pnpm update <pkg>`
+- 固定バージョン → `pnpm add [-D] <pkg>@<target-version>`
+- `@latest` 禁止ルールはそのまま
+
+**Go**:
+- `go get <module>@<patched-version>`
+- `go mod tidy` で整理
+
+#### Phase 4: Dismiss（カテゴリ B, C）
+- 現状のスクリプトをそのまま使用（owner/repo 自動検出化のみ）
+
+#### Phase 5: 検証 → 削除
+
+#### Phase 6: 結果レポート
+- 現状通り
+
+### 2. スクリプト群の変更
+
+全スクリプトで owner/repo 引数を廃止し、`git remote get-url origin` から自動検出する共通関数を導入。
+
+#### `scripts/detect-repo.sh`（新規）
+```bash
+# git remote get-url origin をパースして OWNER と REPO を export
+# HTTPS: https://github.com/owner/repo.git
+# SSH: git@github.com:owner/repo.git
+```
+
+#### 既存スクリプトの変更
+- `get-open-alerts.sh`: 引数廃止 → `source detect-repo.sh`
+- `dismiss-alert.sh`: owner/repo 引数廃止 → `source detect-repo.sh`、残りの引数（alert_number, reason, comment）は維持
+- `dismiss-alerts-batch.sh`: 同上（alert_numbers, reason, comment）
+- `get-alert-detail.sh`: owner/repo 引数廃止 → `source detect-repo.sh`、alert_number は維持
+
+### 3. `references/api-notes.md`
+- 現状のまま（すでにリポジトリ非依存の内容）
+- Go エコシステム向けの注意事項を追記:
+  - `go get` でのバージョン指定方法
+  - `// indirect` 依存の扱い
+
+## ファイル構成
+
+```
+~/.claude/commands/dependabot-cleanup/
+├── SKILL.md
+├── scripts/
+│   ├── detect-repo.sh      # 新規: owner/repo 自動検出
+│   ├── get-open-alerts.sh   # 改修: 引数廃止
+│   ├── get-alert-detail.sh  # 改修: 引数廃止
+│   ├── dismiss-alert.sh     # 改修: owner/repo引数廃止
+│   └── dismiss-alerts-batch.sh  # 改修: owner/repo引数廃止
+└── references/
+    └── api-notes.md         # Go向け追記
+```
+
+## 検証方法
+
+1. 任意の GitHub リポジトリで `./scripts/get-open-alerts.sh` を実行し、owner/repo が正しく自動検出されることを確認
+2. `./scripts/get-alert-detail.sh <number>` でアラート詳細が取得できることを確認
+3. Claude Code から `/dependabot-cleanup` でスキルが認識されることを確認


### PR DESCRIPTION
## Summary

- homepage-2nd固有のdependabot-cleanupスキルを汎用化し、`~/.claude/skills/`で管理するようdotfilesに追加
- owner/repoをgit remoteから自動検出するdetect-repo.shを導入（ハードコード廃止）
- Node.js(pnpm)に加えGoエコシステムのアラート対応に対応
- setup.shに`~/.claude/skills`へのシンボリックリンクを追加

## Test plan

- [ ] `mac/claude/setup.sh` を実行し、`~/.claude/skills` → `~/dotfiles/mac/claude/skills` のシンボリックリンクが正しく作成されることを確認
- [ ] 任意のGitHubリポジトリで `~/.claude/skills/dependabot-cleanup/scripts/get-open-alerts.sh` を実行し、owner/repoが自動検出されることを確認
- [ ] Claude Codeで `/dependabot-cleanup` がスキルとして認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)