### PR TITLE
refactor: statusline rate limit表示をJSON入力直読みに変更

### DIFF
--- a/mac/claude/statusline.sh
+++ b/mac/claude/statusline.sh
@@ -23,9 +23,14 @@ if [ "$1" = "--test" ]; then
         echo ""
     }
 
-    run_test "git repo root" "{\"workspace\":{\"current_dir\":\"$HOME/ghq/github.com/user/project\",\"project_dir\":\"$HOME/ghq/github.com/user/project\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":15}}"
+    # Dynamic timestamps for test cases
+    now=$(date +%s)
+    five_reset_ts=$((now + 1320))    # 22 minutes from now
+    seven_reset_ts=$((now + 151200)) # 1 day 18 hours from now
 
-    run_test "git repo subdir" "{\"workspace\":{\"current_dir\":\"$HOME/ghq/github.com/user/project/src/lib\",\"project_dir\":\"$HOME/ghq/github.com/user/project\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":45}}"
+    run_test "git repo root" "{\"workspace\":{\"current_dir\":\"$HOME/ghq/github.com/user/project\",\"project_dir\":\"$HOME/ghq/github.com/user/project\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":15},\"rate_limits\":{\"five_hour\":{\"used_percentage\":15.2,\"resets_at\":$five_reset_ts},\"seven_day\":{\"used_percentage\":39.1,\"resets_at\":$seven_reset_ts}}}"
+
+    run_test "git repo subdir" "{\"workspace\":{\"current_dir\":\"$HOME/ghq/github.com/user/project/src/lib\",\"project_dir\":\"$HOME/ghq/github.com/user/project\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":45},\"rate_limits\":{\"five_hour\":{\"used_percentage\":42.3,\"resets_at\":$five_reset_ts},\"seven_day\":{\"used_percentage\":55.0,\"resets_at\":$seven_reset_ts}}}"
 
     run_test "no project (null)" "{\"workspace\":{\"current_dir\":\"$HOME/Downloads/folder\",\"project_dir\":null},\"model\":{\"display_name\":\"Sonnet\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":55}}"
 
@@ -34,6 +39,21 @@ if [ "$1" = "--test" ]; then
     run_test "ctx 50% (yellow)" "{\"workspace\":{\"current_dir\":\"$HOME/test\",\"project_dir\":\"$HOME/test\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":50}}"
 
     run_test "ctx 80% (red)" "{\"workspace\":{\"current_dir\":\"$HOME/test\",\"project_dir\":\"$HOME/test\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":80}}"
+
+    run_test "rate limit green" "{\"workspace\":{\"current_dir\":\"$HOME/test\",\"project_dir\":\"$HOME/test\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":20},\"rate_limits\":{\"five_hour\":{\"used_percentage\":15.0,\"resets_at\":$five_reset_ts},\"seven_day\":{\"used_percentage\":25.0,\"resets_at\":$seven_reset_ts}}}"
+
+    run_test "rate limit yellow" "{\"workspace\":{\"current_dir\":\"$HOME/test\",\"project_dir\":\"$HOME/test\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":20},\"rate_limits\":{\"five_hour\":{\"used_percentage\":55.0,\"resets_at\":$five_reset_ts},\"seven_day\":{\"used_percentage\":65.0,\"resets_at\":$seven_reset_ts}}}"
+
+    run_test "rate limit red" "{\"workspace\":{\"current_dir\":\"$HOME/test\",\"project_dir\":\"$HOME/test\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":20},\"rate_limits\":{\"five_hour\":{\"used_percentage\":85.0,\"resets_at\":$five_reset_ts},\"seven_day\":{\"used_percentage\":92.0,\"resets_at\":$seven_reset_ts}}}"
+
+    run_test "no rate limits" "{\"workspace\":{\"current_dir\":\"$HOME/test\",\"project_dir\":\"$HOME/test\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":30}}"
+
+    past_ts=$((now - 600))  # 10 minutes ago
+    run_test "reset already passed" "{\"workspace\":{\"current_dir\":\"$HOME/test\",\"project_dir\":\"$HOME/test\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":20},\"rate_limits\":{\"five_hour\":{\"used_percentage\":85.0,\"resets_at\":$past_ts},\"seven_day\":{\"used_percentage\":42.0,\"resets_at\":$seven_reset_ts}}}"
+
+    run_test "only five_hour" "{\"workspace\":{\"current_dir\":\"$HOME/test\",\"project_dir\":\"$HOME/test\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":20},\"rate_limits\":{\"five_hour\":{\"used_percentage\":50.0,\"resets_at\":$five_reset_ts}}}"
+
+    run_test "only seven_day" "{\"workspace\":{\"current_dir\":\"$HOME/test\",\"project_dir\":\"$HOME/test\"},\"model\":{\"display_name\":\"Opus\"},\"output_style\":{\"name\":\"default\"},\"context_window\":{\"used_percentage\":20},\"rate_limits\":{\"seven_day\":{\"used_percentage\":70.0,\"resets_at\":$seven_reset_ts}}}"
 
     exit 0
 fi
@@ -51,14 +71,18 @@ get_usage_color() {
     fi
 }
 
-# Read JSON input
+# Read JSON input and extract all values in a single jq call
 input=$(cat)
-
-# Extract values
-cwd=$(echo "$input" | jq -r '.workspace.current_dir')
-project_dir=$(echo "$input" | jq -r '.workspace.project_dir // empty')
-model=$(echo "$input" | jq -r '.model.display_name')
-output_style=$(echo "$input" | jq -r '.output_style.name')
+eval "$(echo "$input" | jq -r '
+  @sh "cwd=\(.workspace.current_dir)",
+  @sh "project_dir=\(.workspace.project_dir // "")",
+  @sh "model=\(.model.display_name)",
+  @sh "used_pct=\(.context_window.used_percentage // "")",
+  @sh "five_pct=\(.rate_limits.five_hour.used_percentage // "")",
+  @sh "five_reset=\(.rate_limits.five_hour.resets_at // "")",
+  @sh "seven_pct=\(.rate_limits.seven_day.used_percentage // "")",
+  @sh "seven_reset=\(.rate_limits.seven_day.resets_at // "")"
+')"
 
 # Format directory (show relative to project root)
 if [ -n "$project_dir" ] && [ "$project_dir" != "null" ] && [ "$cwd" != "$project_dir" ]; then
@@ -89,135 +113,67 @@ model_info=" | $(printf '\033[95m')${model}$(printf '\033[0m')"
 
 # Calculate context usage if available
 context_info=""
-used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
 if [ -n "$used_pct" ]; then
     used_int=$(printf "%.0f" "$used_pct")
     ctx_color=$(get_usage_color "$used_int")
     context_info=" | ctx: ${ctx_color}${used_int}%${RESET}"
 fi
 
-# Fetch Claude subscription usage (with cache)
+# Rate limit info from JSON input (Claude Code v2.1.80+)
+# Note: Claude Code provides both five_hour and seven_day together, but we handle partial data gracefully.
 usage_info=""
-CACHE_FILE="/tmp/claude-usage-cache.json"
-CACHE_MAX_AGE=300  # 5 minutes
-OP_CLAUDE_TOKEN_ITEM_NAME="Claude OAuth token"  # Name of the 1Password item storing the oauth token
+if [ -n "$five_pct" ] || [ -n "$seven_pct" ]; then
+    now_epoch=$(date +%s)
+    parts=()
 
-fetch_usage() {
-	TOKEN=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null | jq -r '.claudeAiOauth.accessToken // empty')
-	if [ -n "$TOKEN" ]; then
-        # Use --config with process substitution to avoid exposing token in process list
-        curl --max-time 3 \
-            -K <(printf '%s\n' \
-                "-H \"Authorization: Bearer $TOKEN\"" \
-                "-H \"anthropic-beta: oauth-2025-04-20\"" \
-                "-H \"Content-Type: application/json\"") \
-            "https://api.anthropic.com/api/oauth/usage" 2>/dev/null
-    fi
-	# Example response:
-    # {
-    #   "five_hour": {
-    #     "utilization": 7.0,
-    #     "resets_at": "2026-01-20T08:00:00.425335+00:00"
-    #   },
-    #   "seven_day": {
-    #     "utilization": 38.0,
-    #     "resets_at": "2026-01-22T02:00:00.425356+00:00"
-    #   },
-    #   "seven_day_oauth_apps": null,
-    #   "seven_day_opus": null,
-    #   "seven_day_sonnet": {
-    #     "utilization": 36.0,
-    #     "resets_at": "2026-01-25T07:00:00.425364+00:00"
-    #   },
-    #   "iguana_necktie": null,
-    #   "extra_usage": {
-    #     "is_enabled": false,
-    #     "monthly_limit": null,
-    #     "used_credits": null,
-    #     "utilization": null
-    #   }
-    # }
-}
-
-get_usage() {
-    local now=$(date +%s)
-    local cache_time=0
-
-    # Check cache
-    if [ -f "$CACHE_FILE" ]; then
-        cache_time=$(stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0)
-        local age=$((now - cache_time))
-        if [ $age -lt $CACHE_MAX_AGE ]; then
-            cat "$CACHE_FILE"
-            return
-        fi
-    fi
-
-    # Fetch fresh data
-    local usage=$(fetch_usage)
-    if [ -n "$usage" ] && echo "$usage" | jq -e '.five_hour' >/dev/null 2>&1; then
-        echo "$usage" > "$CACHE_FILE"
-        echo "$usage"
-    elif [ -f "$CACHE_FILE" ]; then
-        # Use stale cache on error
-        cat "$CACHE_FILE"
-    fi
-}
-
-usage_data=$(get_usage)
-if [ -n "$usage_data" ]; then
-    five_hour=$(echo "$usage_data" | jq -r '.five_hour.utilization // empty')
-    five_hour_reset=$(echo "$usage_data" | jq -r '.five_hour.resets_at // empty')
-    seven_day=$(echo "$usage_data" | jq -r '.seven_day.utilization // empty')
-    seven_day_reset=$(echo "$usage_data" | jq -r '.seven_day.resets_at // empty')
-
-    if [ -n "$five_hour" ] && [ -n "$seven_day" ]; then
-        five_int=$(printf "%.0f" "$five_hour")
-        seven_int=$(printf "%.0f" "$seven_day")
-        now_epoch=$(date +%s)
-
-        # Calculate remaining time until 5h reset
+    # 5-hour window
+    if [ -n "$five_pct" ]; then
+        five_int=$(printf "%.0f" "$five_pct")
         five_reset_time=""
-        if [ -n "$five_hour_reset" ]; then
-            utc_time="${five_hour_reset%%.*}+0000"
-            reset_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "$utc_time" "+%s" 2>/dev/null)
-            if [ -n "$reset_epoch" ]; then
-                remaining=$((reset_epoch - now_epoch))
-                if [ $remaining -gt 0 ]; then
-                    hours=$((remaining / 3600))
-                    minutes=$(((remaining % 3600) / 60))
-                    if [ $hours -gt 0 ]; then
-                        five_reset_time="${hours}h${minutes}m"
-                    else
-                        five_reset_time="${minutes}m"
-                    fi
+        if [ -n "$five_reset" ]; then
+            remaining=$((five_reset - now_epoch))
+            if [ $remaining -gt 0 ]; then
+                hours=$((remaining / 3600))
+                minutes=$(((remaining % 3600) / 60))
+                if [ $hours -gt 0 ]; then
+                    five_reset_time="${hours}h"
+                    [ $minutes -gt 0 ] && five_reset_time="${five_reset_time}${minutes}m"
+                else
+                    five_reset_time="${minutes}m"
                 fi
             fi
         fi
-
-        # Calculate remaining time until 7d reset
-        seven_reset_time=""
-        if [ -n "$seven_day_reset" ]; then
-            utc_time="${seven_day_reset%%.*}+0000"
-            reset_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "$utc_time" "+%s" 2>/dev/null)
-            if [ -n "$reset_epoch" ]; then
-                remaining=$((reset_epoch - now_epoch))
-                if [ $remaining -gt 0 ]; then
-                    days=$((remaining / 86400))
-                    hours=$(((remaining % 86400) / 3600))
-                    if [ $days -gt 0 ]; then
-                        seven_reset_time="${days}d${hours}h"
-                    else
-                        seven_reset_time="${hours}h"
-                    fi
-                fi
-            fi
-        fi
-
         five_color=$(get_usage_color "$five_int")
-        seven_color=$(get_usage_color "$seven_int")
-        usage_info=" | limit: ${five_color}${five_int}%${RESET}(${five_reset_time}), ${seven_color}${seven_int}%${RESET}(${seven_reset_time})"
+        five_display="${five_int}%"
+        [ -n "$five_reset_time" ] && five_display="${five_display}(${five_reset_time})"
+        parts+=("${five_color}${five_display}${RESET}")
     fi
+
+    # 7-day window
+    if [ -n "$seven_pct" ]; then
+        seven_int=$(printf "%.0f" "$seven_pct")
+        seven_reset_time=""
+        if [ -n "$seven_reset" ]; then
+            remaining=$((seven_reset - now_epoch))
+            if [ $remaining -gt 0 ]; then
+                days=$((remaining / 86400))
+                hours=$(((remaining % 86400) / 3600))
+                if [ $days -gt 0 ]; then
+                    seven_reset_time="${days}d"
+                    [ $hours -gt 0 ] && seven_reset_time="${seven_reset_time}${hours}h"
+                else
+                    seven_reset_time="${hours}h"
+                fi
+            fi
+        fi
+        seven_color=$(get_usage_color "$seven_int")
+        seven_display="${seven_int}%"
+        [ -n "$seven_reset_time" ] && seven_display="${seven_display}(${seven_reset_time})"
+        parts+=("${seven_color}${seven_display}${RESET}")
+    fi
+
+    # Join parts with ", "
+    usage_info=" | limit: $(printf '%s' "${parts[0]}")$([ ${#parts[@]} -gt 1 ] && printf ', %s' "${parts[1]}")"
 fi
 
 # Build status line (Starship-style: dir + git + model + context + usage)

--- a/plans/2026-03-23-statusline-rate-limits.md
+++ b/plans/2026-03-23-statusline-rate-limits.md
@@ -1,0 +1,84 @@
+# ステータスライン rate_limits 改善プラン
+
+## Context
+
+`statusline.sh` のレートリミット表示は、現在 macOS Keychain からOAuthトークンを取得し `api.anthropic.com/api/oauth/usage` をAPI呼び出ししている（99-221行目、約120行）。Claude Code v2.1.80+ では `rate_limits` フィールドがJSON入力として直接渡されるようになったため、API呼び出し・キャッシュ・トークン取得がすべて不要になる。
+
+参考: https://nyosegawa.com/posts/claude-code-statusline-rate-limits/
+
+## 対象ファイル
+
+- `/Users/korosuke613/dotfiles/mac/claude/statusline.sh`（唯一の変更対象）
+
+## 変更内容
+
+### 1. 削除するもの（99-221行目）
+
+| 対象 | 理由 |
+|------|------|
+| `CACHE_FILE`, `CACHE_MAX_AGE` 変数 | キャッシュ不要 |
+| `OP_CLAUDE_TOKEN_ITEM_NAME` 変数 | OAuthトークン不要 |
+| `fetch_usage()` 関数（security + curl） | API呼び出し不要 |
+| `get_usage()` 関数（キャッシュロジック） | キャッシュ不要 |
+| ISO 8601 → epoch 変換（`date -j -f`） | Unixタイムスタンプ直接使用 |
+
+### 2. 新コード（99行目以降に挿入）
+
+JSON入力の `rate_limits` から直接読み取る:
+
+```bash
+usage_info=""
+five_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+five_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+seven_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+seven_reset=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+
+if [ -n "$five_pct" ] && [ -n "$seven_pct" ]; then
+    five_int=$(printf "%.0f" "$five_pct")
+    seven_int=$(printf "%.0f" "$seven_pct")
+    now_epoch=$(date +%s)
+
+    # 5h残り時間（算術演算のみ）
+    five_reset_time=""
+    if [ -n "$five_reset" ]; then
+        remaining=$((five_reset - now_epoch))
+        # ... hours/minutes計算（現行と同じロジック）
+    fi
+
+    # 7d残り時間（同上）
+    seven_reset_time=""
+    if [ -n "$seven_reset" ]; then
+        remaining=$((seven_reset - now_epoch))
+        # ... days/hours計算（現行と同じロジック）
+    fi
+
+    # 色分け・表示フォーマットは現行と同一
+    usage_info=" | limit: ${five_color}${five_int}%${RESET}(...), ${seven_color}${seven_int}%${RESET}(...)"
+fi
+```
+
+### 3. テストケース更新（16-39行目）
+
+- テストブロック冒頭に動的タイムスタンプ変数を追加
+- 既存テストケースのJSONに `rate_limits` フィールドを追加
+- 新規テストケース追加: green / yellow / red / rate_limitsなし
+
+## Before / After
+
+| 項目 | Before | After |
+|------|--------|-------|
+| 行数（99-221） | ~123行 | ~40行 |
+| 外部依存 | `security`, `curl`, `jq`, `date -j -f` | `jq`, `date +%s` |
+| キャッシュ | `/tmp/claude-usage-cache.json` | なし |
+| ネットワーク | あり（最大3秒timeout） | なし |
+| 時刻パース | ISO 8601変換 | Unixタイムスタンプ直接 |
+
+## 検証
+
+```bash
+bash ~/dotfiles/mac/claude/statusline.sh --test
+```
+
+- 各色（緑/黄/赤）の正しい表示
+- rate_limitsなしの場合にusage_info空
+- 残り時間フォーマット（`22m`, `1h30m`, `1d18h`）


### PR DESCRIPTION
## Summary

Claude Code v2.1.80+が提供する`rate_limits`フィールドを使用し、ステータスラインのrate limit表示を改善。

- 外部API呼び出し（`security` + `curl` + キャッシュ）を完全に廃止し、JSON入力の`rate_limits`フィールドから直読みに変更
- `jq`呼び出しを8回→1回に統合（`eval` + `@sh`パターン）
- 片方のみのデータ（`five_hour`のみ / `seven_day`のみ）にも対応
- リセット済み時の空カッコ表示を修正（`85%()` → `85%`）
- 端数ゼロ省略（`1h0m` → `1h`、`1d0h` → `1d`）
- テストケースを6件→13件に拡充

## Test plan

- [x] `bash ~/.claude/statusline.sh --test` で全13テストケースが正常に表示される
- [x] Claude Code上でステータスラインにrate limit情報が正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)